### PR TITLE
Update NumFOCUS donation link

### DIFF
--- a/_sources/index.rst.txt
+++ b/_sources/index.rst.txt
@@ -65,4 +65,4 @@ Helpful Links
 .. _github: https://github.com/PyTables/PyTables
 .. _`mailing list`: https://groups.google.com/group/pytables-users
 .. _`NumFOCUS project`: http://www.numfocus.org/open-source-projects.html
-.. _`donating to NumFOCUS`: https://numfocus.salsalabs.org/donate-to-pytables/index.html
+.. _`donating to NumFOCUS`: https://numfocus.org/donate-to-pytables

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@ involved with this project, please contact us via <a class="reference external" 
 <a class="reference external image-reference" href="http://www.numfocus.org"><img alt="NumFocus Sponsored Stamp" class="align-center" src="_images/NumFocusSponsoredStamp.png" style="width: 300px;" /></a>
 <p>Since August 2015, PyTables is a <a class="reference external" href="http://www.numfocus.org/open-source-projects.html">NumFOCUS project</a>, which means that
 your donations are fiscally sponsored under the NumFOCUS umbrella.  Please
-consider <a class="reference external" href="https://numfocus.salsalabs.org/donate-to-pytables/index.html">donating to NumFOCUS</a>.</p>
+consider <a class="reference external" href="https://numfocus.org/donate-to-pytables">donating to NumFOCUS</a>.</p>
 <section id="contents">
 <h2>Contents<a class="headerlink" href="#contents" title="Permalink to this heading">¶</a></h2>
 <div class="toctree-wrapper compound">


### PR DESCRIPTION
Use the up-to-date link recommended by a NumFOCUS staff member who noticed that the link was outdated (notified via @FrancescAlted).

I updated the link directly in the ReST and HTML files without re-generating the whole site.